### PR TITLE
fix(ui): improve grid cell and row spacing for better readability

### DIFF
--- a/app/components/HeatmapGrid.vue
+++ b/app/components/HeatmapGrid.vue
@@ -48,7 +48,7 @@ const minuteMarks = [0, 10, 20, 30, 40, 50]
   align-items: center;
   gap:         10px;
   padding:     0 4px;
-  margin-bottom: 4px;
+  margin-bottom: 8px;
 }
 
 /* checkbox (16) + gap (10) + label (40) = 66px */
@@ -85,6 +85,6 @@ const minuteMarks = [0, 10, 20, 30, 40, 50]
 .rows-container {
   display:        flex;
   flex-direction: column;
-  gap:            2px;
+  gap:            4px;
 }
 </style>

--- a/app/components/HeatmapRow.vue
+++ b/app/components/HeatmapRow.vue
@@ -161,7 +161,7 @@ function showTooltip(bucket: Bucket, event: MouseEvent) {
   display:     flex;
   align-items: center;
   gap:         10px;
-  padding:     2px 4px;
+  padding:     4px 6px;
   border-radius: 6px;
   transition:  background 100ms ease;
 }
@@ -243,12 +243,12 @@ function showTooltip(bucket: Bucket, event: MouseEvent) {
   flex:    1;
   display: grid;
   grid-template-columns: repeat(60, 1fr);
-  gap:     2px;
+  gap:     3px;
 }
 
 .cell {
-  height:        16px;
-  border-radius: 2px;
+  height:        18px;
+  border-radius: 3px;
   cursor:        pointer;
   outline:       none;
   border:        none;

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -22,15 +22,15 @@
         </div>
 
         <!-- 24 hour rows -->
-        <div class="flex flex-col gap-[2px]">
+        <div class="flex flex-col gap-[4px]">
           <div
             v-for="i in 24"
             :key="i"
-            class="flex items-center gap-[10px] px-1 py-[2px]"
+            class="flex items-center gap-[10px] px-[6px] py-[4px]"
           >
             <USkeleton class="w-4 h-4 rounded-sm flex-shrink-0" />
             <USkeleton class="w-[40px] h-[11px] rounded-full flex-shrink-0" />
-            <USkeleton class="flex-1 h-4 rounded" />
+            <USkeleton class="flex-1 h-[18px] rounded" />
             <USkeleton class="w-[195px] h-[11px] rounded-full flex-shrink-0" />
           </div>
         </div>


### PR DESCRIPTION
Grid hücre ve satır aralıkları okunabilirlik için düzenlendi

Hücreler ve satırlar arası boşluklar yetersiz ve tutarsızdı.

Yapılan değişiklikler:
- Satır arası boşluk: 2px → 4px
- Satır padding (dikey): 2px → 4px, (yatay): 4px → 6px
- Hücre arası boşluk: 2px → 3px
- Hücre yüksekliği: 16px → 18px
- Hücre border-radius: 2px → 3px
- Dakika ekseni alt boşluk: 4px → 8px
- Skeleton, gerçek grid ile aynı boyutları kullanacak şekilde güncellendi

Closes [#8](https://github.com/batuhanozhan/frontend-challenge-1/issues/8)